### PR TITLE
Make tonce more granular

### DIFF
--- a/kuna/kuna.py
+++ b/kuna/kuna.py
@@ -145,7 +145,7 @@ class KunaAPI(object):
 
         if is_user_method:
             args['access_key'] = self.access_key
-            args['tonce'] = int(time.time()) * 1000
+            args['tonce'] = int(time.time() * 1000)
             args['signature'] = self._generate_signature(method, path, args)
 
         try:


### PR DESCRIPTION
Currently, there is no way to send more than one request per second without triggering `tonce` errors